### PR TITLE
🔄 add RSS feed support with locale-aware routes and update translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ Great that you are considering supporting the project. You have a lot of ways to
 ## TODO
 
 - [x] Improve SEO and accessibility
+- [x] Add RSS feed (RSS 2.0, Atom, JSON Feed; per-locale).
 - [] Config test packages (like `vitest`) and Add unit test
-- [] Add RSS feed.
 
 ## License
 

--- a/app/app.vue
+++ b/app/app.vue
@@ -4,13 +4,26 @@ const config = useRuntimeConfig()
 // Locale-aware <html lang/dir>, hreflang alternates (incl. x-default), og:locale and
 // canonical links — all derived from the active i18n locale.
 const i18nHead = useLocaleHead({ seo: true })
+const { locale } = useI18n()
+// Absolute feed base so the autodiscovery <link>s resolve even when an HTML scraper has
+// no base URL (matches the absolute hreflang/canonical links above). Falls back to a
+// root-relative path when siteUrl is unset (local dev).
+const feedBase = computed(() => {
+  const origin = (config.public.siteUrl ?? '').replace(/\/$/, '')
+  return `${origin}${locale.value === 'fa' ? '/fa' : ''}`
+})
 
 useHead(() => ({
   htmlAttrs: {
     lang: i18nHead.value.htmlAttrs?.lang,
     dir: i18nHead.value.htmlAttrs?.dir as 'ltr' | 'rtl' | 'auto' | undefined,
   },
-  link: [...(i18nHead.value.link || [])],
+  link: [
+    ...(i18nHead.value.link || []),
+    { rel: 'alternate', type: 'application/rss+xml', title: 'Alireza Esfahani — RSS', href: `${feedBase.value}/rss.xml` },
+    { rel: 'alternate', type: 'application/atom+xml', title: 'Alireza Esfahani — Atom', href: `${feedBase.value}/atom.xml` },
+    { rel: 'alternate', type: 'application/feed+json', title: 'Alireza Esfahani — JSON Feed', href: `${feedBase.value}/feed.json` },
+  ],
   meta: [
     ...(i18nHead.value.meta || []),
     config.public.isStaging

--- a/app/pages/articles/index.vue
+++ b/app/pages/articles/index.vue
@@ -10,6 +10,9 @@ const pageSize = Number(config.public.pageSize) || 10
 
 const langFor = (l: string) => (l === 'en' ? 'en-us' : 'fa-ir')
 
+// Locale-aware feed: /rss.xml on en, /fa/rss.xml on fa.
+const rssHref = computed(() => (locale.value === 'fa' ? '/fa/rss.xml' : '/rss.xml'))
+
 const { data, refresh } = await useAsyncData(
   () => `articles-list-${locale.value}`,
   async () => {
@@ -99,6 +102,19 @@ defineOgImage('Default', {
       <div v-if="articles.length > 0 && totalPages === page" class="done">
         &bull; &bull;
       </div>
+      <a
+        v-if="articles.length > 0"
+        class="rss-link"
+        :href="rssHref"
+        :title="t('articles.subscribe')"
+        :aria-label="t('articles.subscribe')"
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <circle cx="6.18" cy="17.82" r="2.18" />
+          <path d="M4 4.44v2.83c7.03 0 12.73 5.7 12.73 12.73h2.83C19.56 11.4 12.6 4.44 4 4.44z" />
+          <path d="M4 10.1v2.83c3.9 0 7.07 3.17 7.07 7.07h2.83c0-5.47-4.43-9.9-9.9-9.9z" />
+        </svg>
+      </a>
     </footer>
   </section>
 </template>
@@ -136,5 +152,23 @@ footer {
 
 .done {
   color: var(--text-light);
+}
+
+.rss-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 24px;
+  color: var(--text-light);
+  font-family: var(--text-font);
+  font-size: 14px;
+  transition: color 0.2s ease-in-out;
+  svg {
+    display: block;
+  }
+  &:hover,
+  &:focus-visible {
+    color: var(--primary-text);
+  }
 }
 </style>

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -15,7 +15,8 @@
   },
   "articles": {
     "title": "Articles",
-    "readTime": "{min} min read"
+    "readTime": "{min} min read",
+    "subscribe": "Subscribe via RSS"
   },
   "projects": {
     "demo": "Demo ↗"

--- a/i18n/locales/fa.json
+++ b/i18n/locales/fa.json
@@ -15,7 +15,8 @@
   },
   "articles": {
     "title": "نوشته‌ها",
-    "readTime": "خواندن {min} دقیقه"
+    "readTime": "خواندن {min} دقیقه",
+    "subscribe": "اشتراک از طریق RSS"
   },
   "projects": {
     "demo": "پیش‌نمایش ↖"

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -182,7 +182,16 @@ export default defineNuxtConfig({
 
   nitro: {
     prerender: {
-      routes: ['/sitemap.xml', '/robots.txt'],
+      routes: [
+        '/sitemap.xml',
+        '/robots.txt',
+        '/rss.xml',
+        '/atom.xml',
+        '/feed.json',
+        '/fa/rss.xml',
+        '/fa/atom.xml',
+        '/fa/feed.json',
+      ],
     },
   },
 })

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@prismicio/client": "^7.10.0",
     "@prismicio/vue": "^5.1.0",
     "ai": "^6.0.191",
+    "feed": "^5.2.1",
     "nuxt": "^4.0.0",
     "nuxt-gtag": "^4.0.0",
     "nuxt-og-image": "^6.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       ai:
         specifier: ^6.0.191
         version: 6.0.191(zod@4.4.3)
+      feed:
+        specifier: ^5.2.1
+        version: 5.2.1
       nuxt:
         specifier: ^4.0.0
         version: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.4(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.4))(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(typescript@5.9.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.2(typescript@5.9.3))(yaml@2.9.0)
@@ -4188,6 +4191,10 @@ packages:
       picomatch:
         optional: true
 
+  feed@5.2.1:
+    resolution: {integrity: sha512-jTynzYPWs9ALjro0GW8j7sv9y7cJBeOdD4Y88kVqYy/eyusIX3g+499JiTDIlD9Ge/unebx57T4Uzo6vpYvMtA==}
+    engines: {node: '>=20', pnpm: '>=10'}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -6727,6 +6734,10 @@ packages:
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
+
+  xml-js@1.6.11:
+    resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
+    hasBin: true
 
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
@@ -10943,6 +10954,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  feed@5.2.1:
+    dependencies:
+      xml-js: 1.6.11
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -14557,6 +14572,10 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
+
+  xml-js@1.6.11:
+    dependencies:
+      sax: 1.6.0
 
   xml-name-validator@4.0.0: {}
 

--- a/server/routes/atom.xml.get.ts
+++ b/server/routes/atom.xml.get.ts
@@ -1,0 +1,3 @@
+import { defineFeedRoute } from '~~/server/utils/feed'
+
+export default defineEventHandler(event => defineFeedRoute(event, 'en', 'atom'))

--- a/server/routes/fa/atom.xml.get.ts
+++ b/server/routes/fa/atom.xml.get.ts
@@ -1,0 +1,3 @@
+import { defineFeedRoute } from '~~/server/utils/feed'
+
+export default defineEventHandler(event => defineFeedRoute(event, 'fa', 'atom'))

--- a/server/routes/fa/feed.json.get.ts
+++ b/server/routes/fa/feed.json.get.ts
@@ -1,0 +1,3 @@
+import { defineFeedRoute } from '~~/server/utils/feed'
+
+export default defineEventHandler(event => defineFeedRoute(event, 'fa', 'json'))

--- a/server/routes/fa/rss.xml.get.ts
+++ b/server/routes/fa/rss.xml.get.ts
@@ -1,0 +1,3 @@
+import { defineFeedRoute } from '~~/server/utils/feed'
+
+export default defineEventHandler(event => defineFeedRoute(event, 'fa', 'rss'))

--- a/server/routes/feed.json.get.ts
+++ b/server/routes/feed.json.get.ts
@@ -1,0 +1,3 @@
+import { defineFeedRoute } from '~~/server/utils/feed'
+
+export default defineEventHandler(event => defineFeedRoute(event, 'en', 'json'))

--- a/server/routes/rss.xml.get.ts
+++ b/server/routes/rss.xml.get.ts
@@ -1,0 +1,3 @@
+import { defineFeedRoute } from '~~/server/utils/feed'
+
+export default defineEventHandler(event => defineFeedRoute(event, 'en', 'rss'))

--- a/server/utils/feed.ts
+++ b/server/utils/feed.ts
@@ -1,0 +1,109 @@
+import { Feed } from 'feed'
+import { asText, createClient, filter, type RichTextField } from '@prismicio/client'
+import type { H3Event } from 'h3'
+import { useRuntimeConfig } from '#imports'
+
+type Locale = 'en' | 'fa'
+type FeedFormat = 'rss' | 'atom' | 'json'
+
+// Locale → Prismic lang, URL prefix, channel language tag, and the articles-page
+// description (kept in sync with i18n/locales/*.json `seo.articles`; the i18n runtime
+// isn't available in a Nitro route, so the strings live here).
+const LOCALES: Record<Locale, { lang: string, prefix: string, language: string, description: string }> = {
+  en: {
+    lang: 'en-us',
+    prefix: '',
+    language: 'en',
+    description: 'Articles by Alireza Esfahani on life, software engineering, front-end, and web development.',
+  },
+  fa: {
+    lang: 'fa-ir',
+    prefix: '/fa',
+    language: 'fa',
+    description: 'نوشته‌های علیرضا اصفهانی درباره زندگی، مهندسی نرم‌افزار، فرانت‌اند و توسعه وب.',
+  },
+}
+
+const MAX_ITEMS = 50
+
+function buildEmptyFeed(locale: Locale, site: string): Feed {
+  const { prefix, language, description } = LOCALES[locale]
+  return new Feed({
+    title: 'Alireza Esfahani',
+    description,
+    id: `${site}${prefix}/articles`,
+    link: `${site}${prefix}/articles`,
+    language,
+    favicon: `${site}/favicon-32x32.png`,
+    copyright: `© ${new Date().getFullYear()} Alireza Esfahani`,
+    author: { name: 'Alireza Esfahani', link: site },
+    feedLinks: {
+      rss: `${site}${prefix}/rss.xml`,
+      atom: `${site}${prefix}/atom.xml`,
+      json: `${site}${prefix}/feed.json`,
+    },
+  })
+}
+
+export async function buildFeed(locale: Locale, event?: H3Event): Promise<Feed> {
+  const { public: { apiUrl, siteUrl } } = useRuntimeConfig(event)
+  const site = (siteUrl ?? '').replace(/\/$/, '')
+  const feed = buildEmptyFeed(locale, site)
+
+  if (!apiUrl) {
+    console.warn('[feed] NUXT_PUBLIC_API_URL is unset; serving empty feed')
+    return feed
+  }
+
+  try {
+    const { lang, prefix } = LOCALES[locale]
+    const client = createClient(apiUrl, { fetch })
+    const response = await client.get({
+      filters: [filter.at('document.type', 'articles')],
+      lang,
+      pageSize: MAX_ITEMS,
+      page: 1,
+      orderings: { field: 'document.first_publication_date', direction: 'desc' },
+    })
+
+    let newest: Date | undefined
+    for (const doc of response.results) {
+      if (!doc.uid) continue
+      const url = `${site}${prefix}/articles/${doc.uid}`
+      const date = new Date(doc.first_publication_date)
+      if (!newest || date > newest) newest = date
+      feed.addItem({
+        title: asText(doc.data.article_title as RichTextField),
+        id: url,
+        link: url,
+        description: asText(doc.data.article_subtitle as RichTextField),
+        date,
+        category: (doc.tags ?? []).map(name => ({ name })),
+      })
+    }
+    // `options` is a public, mutable field of Feed; the channel <updated>/<lastBuildDate>
+    // tracks the newest article rather than build time (set post-loop since it's only
+    // known after iterating). Revisit if a future feed major makes options read-only.
+    if (newest) feed.options.updated = newest
+  }
+  catch (err) {
+    console.warn('[feed] failed to load Prismic content:', err)
+  }
+
+  return feed
+}
+
+// Backs every route file: build the locale's feed, set the right Content-Type, serialise.
+export async function defineFeedRoute(event: H3Event, locale: Locale, format: FeedFormat): Promise<string> {
+  const feed = await buildFeed(locale, event)
+  if (format === 'json') {
+    setHeader(event, 'Content-Type', 'application/feed+json; charset=utf-8')
+    return feed.json1()
+  }
+  if (format === 'atom') {
+    setHeader(event, 'Content-Type', 'application/atom+xml; charset=utf-8')
+    return feed.atom1()
+  }
+  setHeader(event, 'Content-Type', 'application/rss+xml; charset=utf-8')
+  return feed.rss2()
+}


### PR DESCRIPTION
# Add RSS / Atom / JSON feeds for articles

## Summary

Adds per-locale syndication feeds for the Prismic-backed articles, plus autodiscovery and a visible subscribe link. Closes the `Add RSS feed` README TODO.

- **Two locales, three formats** — `/rss.xml`, `/atom.xml`, `/feed.json` (English) and `/fa/rss.xml`, `/fa/atom.xml`, `/fa/feed.json` (Farsi), generated from one definition via the [`feed`](https://www.npmjs.com/package/feed) library.
- **Summary-only items** — title, subtitle, absolute link, publish date, tags as categories. 50 most recent articles per feed, newest first.
- **Server-side, graceful** — `server/utils/feed.ts` fetches from Prismic mirroring the existing `server/plugins/sitemap-prismic.ts` pattern; returns a valid empty feed (never 500s) when `apiUrl` is unset or Prismic errors.
- **Autodiscovery** — per-locale `<link rel="alternate">` tags (RSS + Atom + JSON) in `app.vue`, with absolute hrefs.
- **Prerendered** — the six routes are emitted as static files at build time.
- **Visible link** — an RSS link in the Articles page footer (locale-aware), for humans; Atom/JSON stay discovery-only.

## Why direct `feed` lib (no Nuxt module)

No maintained, Prismic-friendly Nuxt 4 feed module exists: `nuxt-feedme` (only Nuxt-4-current one) hard-depends on `@nuxt/content` (this project uses Prismic); `nuxt-module-feed` is ~2 years stale and pinned to Nuxt 3. Both just wrap `feed` anyway. Using it directly mirrors the existing sitemap pattern and keeps full control of the bilingual setup.

## Changes

| Area | File | Change |
| --- | --- | --- |
| Dep | `package.json`, `pnpm-lock.yaml` | add `feed@^5.2.1` |
| Builder | `server/utils/feed.ts` | `buildFeed(locale, event?)` + `defineFeedRoute(event, locale, format)` |
| Routes | `server/routes/{rss.xml,atom.xml,feed.json}.get.ts` + `server/routes/fa/*` | six endpoints |
| Discovery | `app/app.vue` | per-locale `<link rel="alternate">` (absolute hrefs) |
| Prerender | `nuxt.config.ts` | six routes added to `nitro.prerender.routes` |
| UI | `app/pages/articles/index.vue` | locale-aware RSS link in footer |
| i18n | `i18n/locales/{en,fa}.json` | `articles.subscribe` label |
| Docs | `README.md` | mark TODO done |

## Notes

- Feed/item URLs use `NUXT_PUBLIC_SITE_URL`; localhost in dev, real origin on Vercel (same as the sitemap).
- Atom 1.0 has no `xml:lang` (a `feed` library limitation); locale is conveyed via the `/fa` URL path. JSON Feed likewise.

## Test plan

- [ ] `pnpm build` succeeds; prerender log lists all six feed routes; files exist under `.output/public/`.
- [ ] `pnpm lint` and `pnpm typecheck` clean.
- [ ] All six endpoints return `200` with correct `Content-Type` (`application/rss+xml`, `application/atom+xml`, `application/feed+json`).
- [ ] `/rss.xml` validates on the [W3C Feed Validator](https://validator.w3.org/feed/); `/feed.json` parses as JSON.
- [ ] `/fa/rss.xml` lists Farsi articles with `<language>fa</language>`.
- [ ] Articles page shows the RSS link; href is `/rss.xml` on en and `/fa/rss.xml` on fa.
- [ ] Home page `<head>` advertises the feeds via `<link rel="alternate">`, switching per locale.
